### PR TITLE
Add TODO comment metric

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
           <option value="lines">Lines</option>
           <option value="type_coverage">Type annotation coverage</option>
           <option value="duplication">Code Duplication</option>
+          <option value="todo_comments">TODO comments</option>
         </select>
       </label>
       <button id="resetZoom" class="text-sm border rounded px-2 py-1 hidden">


### PR DESCRIPTION
## Summary
- detect TODO-like comments in Python functions
- expose the new metric in the data model
- add a selection option in the treemap viewer

## Testing
- `ruff format .`
- `ruff check .`
- `mypy .`
- `python main.py .`

------
https://chatgpt.com/codex/tasks/task_e_688795fb8fec832d9caa636c9bf9aee5