### PR TITLE
Enable closing detail pane via blank-space click

### DIFF
--- a/script.js
+++ b/script.js
@@ -46,6 +46,15 @@ resetZoom.addEventListener("click", () => {
     .call(zoomBehaviour.transform, d3.zoomIdentity);
 });
 
+// Close detail pane when clicking anywhere outside of it
+document.addEventListener("click", (e) => {
+  if (!detailPane) return;
+  if (detailPane.contains(e.target)) return;
+  if (e.target.closest("#viz g")) return;
+  detailPane.remove();
+  detailPane = null;
+});
+
 /*******************************************************************
  * Helpers
  *******************************************************************/


### PR DESCRIPTION
## Summary
- allow clicking outside the detail pane to close it

## Testing
- `ruff check .`
- `ruff format .`
- `mypy .`
- `python main.py .`

------
https://chatgpt.com/codex/tasks/task_e_6887994aaa20832d9d5ae74cb98e39d2